### PR TITLE
Update akshara.template

### DIFF
--- a/nginx/akshara.template
+++ b/nginx/akshara.template
@@ -14,8 +14,13 @@ upstream elasticsearch_upstream {
 server {
   listen ${NGINX_PORT} default_server;
   listen [::]:${NGINX_PORT} default_server;
+  listen 443 ssl;
 
   server_name ${NGINX_SERVER_NAME};
+  ssl_certificate      /etc/letsencrypt/live/sangraha.org/fullchain.pem;
+  ssl_certificate_key  /etc/letsencrypt/live/sangraha.org/privkey.pem;
+
+
 
   # for some diagnostics
   location /nginx_status {


### PR DESCRIPTION
This is a temporary fix so that we can run nginx with SSL certs in production. In the long term we should move the nginx back to the docker container and use a volume mounted to share the SSL keys between the container and the host.